### PR TITLE
configure-aws-credentialsのバージョンアップ

### DIFF
--- a/.github/workflows/build-and-deploy.yaml
+++ b/.github/workflows/build-and-deploy.yaml
@@ -38,7 +38,7 @@ jobs:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
       - name: Configure AWS Credentials
         if: startsWith(github.ref, 'refs/heads/main')
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           aws-region: ap-northeast-1
           role-to-assume: ${{ secrets.AWS_DEPLOY_ROLE }}


### PR DESCRIPTION
「Node.js 12 actions are deprecated.」の対策としてconfigure-aws-credentialsのバージョンアップを行う